### PR TITLE
Download sources via spectool

### DIFF
--- a/pullRequest2scratchBuild.sh
+++ b/pullRequest2scratchBuild.sh
@@ -83,7 +83,9 @@ cd ${REPO_NAME}
 
 # Build SRPM
 # Download sources
+ls -la
 spectool -g *.spec
+ls -la
 mock --isolation=simple -r "${mock_config}" --resultdir=./ --buildsrpm --spec *.spec --source . | tee "${srpm_log}"
 srpm_path=$(ls -1 | grep ".src.rpm$" | awk '{ print $1 }')
 srpm_name=$(basename ${srpm_path})

--- a/pullRequest2scratchBuild.sh
+++ b/pullRequest2scratchBuild.sh
@@ -82,7 +82,8 @@ prepare_repository ${REPO_FULL_NAME} ${PR_ID}
 cd ${REPO_NAME}
 
 # Build SRPM
-fedpkg sources
+# Download sources
+spectool -g *.spec
 mock --isolation=simple -r "${mock_config}" --resultdir=./ --buildsrpm --spec *.spec --source . | tee "${srpm_log}"
 srpm_path=$(ls -1 | grep ".src.rpm$" | awk '{ print $1 }')
 srpm_name=$(basename ${srpm_path})


### PR DESCRIPTION
fedpkg seems to be having some trouble in CI:

+ fedpkg sources
Not downloading unused coreos-installer-0.10.1.crate

See: https://pagure.io/rpkg/pull-request/564