### PR TITLE
Run Koji scratch builds with --background

### DIFF
--- a/scratch-build.sh
+++ b/scratch-build.sh
@@ -40,7 +40,7 @@ fi
 
 kinit -k -t ${KOJI_KEYTAB} ${KRB_PRINCIPAL}
 
-koji -p ${profile} build --scratch --fail-fast --nowait ${target} ${source_url} > ${koji_log}
+koji -p ${profile} build --scratch --background --fail-fast --nowait ${target} ${source_url} > ${koji_log}
 cat ${koji_log}
 
 cat ${koji_log} | grep '^Task info: ' | awk '{ print $3 }' > ${koji_url}


### PR DESCRIPTION
This gives them a lower priority. Per @nirik, scratch build tasks from dist-git PRs (both from this pipeline and the zuul one) are currently more or less DoSing Koji. Running them with --background gives them a lower priority, which should help alleviate the pressure somewhat.