### PR TITLE
Increase timeout waiting for scratch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
 
             steps {
                 script {
-                    timeout(time: 240, unit: 'MINUTES') {
+                    timeout(time: 600, unit: 'MINUTES') {
                         def rc = sh(returnStatus: true, script: "./scratch-build.sh koji ${releaseId}-candidate git+https://src.fedoraproject.org/${sourceRepo}.git#${params.PR_COMMIT}")
                         if (fileExists('koji_url')) {
                             kojiUrl = readFile("${env.WORKSPACE}/koji_url").trim()


### PR DESCRIPTION
Scratch builds for some projects take longer than 4 hours, and there may also be delays if koji is under heavy load, e.g. during a mass rebuild. Increase the timeout to 10 hours.

Related to: https://pagure.io/fedora-ci/general/issue/485