### PR TITLE
Reuse previous scratch build if it has the same commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
         string(name: 'PR_UID', defaultValue: '', description: "Pagure's unique internal pull-request Id")
         string(name: 'PR_COMMIT', defaultValue: '', description: 'Commit Id (hash) of the last commit in the pull-request')
         string(name: 'PR_COMMENT', defaultValue: '0', description: "Pagure's internal Id of the comment which triggered CI testing; 0 (zero) if the testing was triggered by simply opening the pull-request")
+        booleanParam(name: 'IGNORE_TASK_ID_CACHE', defaultValue: false, description: "Ignore the previous commit's scratch-build cache")
     }
 
     stages {
@@ -101,8 +102,11 @@ pipeline {
                         }
                     }
                     timeout(time: buildTimeout, unit: 'MINUTES') {
-                        // TODO: Check if a build already exists and if so reuse it
-                        def rc = sh(returnStatus: true, script: "./scratch-build.sh koji ${releaseId}-candidate git+https://src.fedoraproject.org/${sourceRepo}.git#${params.PR_COMMIT}")
+                        // We don't really care if koji_find_task.py fails, the task_id/koji_url should be empty then
+                        def rc = sh(returnStdout: true, script: "python3 ./koji_task.py find ${sourceRepo} ${params.PR_COMMIT}")
+                        if (params.IGNORE_TASK_ID_CACHE || !fileExists('task_id')){
+                            rc = sh(returnStatus: true, script: "./scratch-build.sh koji ${releaseId}-candidate git+https://src.fedoraproject.org/${sourceRepo}.git#${params.PR_COMMIT}")
+                        }
                         if (fileExists('koji_url')) {
                             kojiUrl = readFile("${env.WORKSPACE}/koji_url").trim()
                         }
@@ -114,6 +118,8 @@ pipeline {
                                 error('Failed to scratch build the pull request.')
                             }
                         }
+                        // Similarly with koji_find_task, we don't really care if this fails
+                        rc = sh(returnStdout: true, script: "python3 ./koji_task.py save ${sourceRepo} ${params.PR_COMMIT}")
                         sendMessage(type: 'running', artifactId: artifactId, pipelineMetadata: pipelineMetadata, dryRun: isPullRequest(), runUrl: kojiUrl)
 
                         // Wait for the scratch-build to finish

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ retry (10) {
     }
 }
 
+def buildTimeout = 600
+
 def releaseId
 def sourceRepo
 
@@ -88,7 +90,8 @@ pipeline {
 
             steps {
                 script {
-                    timeout(time: 600, unit: 'MINUTES') {
+                    timeout(time: buildTimeout, unit: 'MINUTES') {
+                        // TODO: Check if a build already exists and if so reuse it
                         def rc = sh(returnStatus: true, script: "./scratch-build.sh koji ${releaseId}-candidate git+https://src.fedoraproject.org/${sourceRepo}.git#${params.PR_COMMIT}")
                         if (fileExists('koji_url')) {
                             kojiUrl = readFile("${env.WORKSPACE}/koji_url").trim()
@@ -139,6 +142,18 @@ pipeline {
                     string(name: 'TEST_PROFILE', value: releaseId)
                 ]
             )
+        }
+        aborted {
+            script{
+                // This can be either because it has timed-out or the job was canceled
+                if (isTimeoutAborted(timeout: buildTimeout, unit: 'MINUTES')) {
+                        // If it times-out than we should do nothing, but send a report to dist-git that it failed
+                    sendMessage(type: 'error', artifactId: artifactId, pipelineMetadata: pipelineMetadata, dryRun: isPullRequest(), runUrl: kojiUrl)
+                } else {
+                        // Otherwise, it probably was canceled, so do not report anything, just cancel the koji build
+                    sh(returnStatus: true, script: "koji cancel ${taskId}")
+                }
+            }
         }
         failure {
             sendMessage(type: 'error', artifactId: artifactId, pipelineMetadata: pipelineMetadata, dryRun: isPullRequest(), runUrl: kojiUrl)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,10 +86,20 @@ pipeline {
             environment {
                 KOJI_KEYTAB = credentials('fedora-keytab')
                 KRB_PRINCIPAL = 'bpeck/jenkins-continuous-infra.apps.ci.centos.org@FEDORAPROJECT.ORG'
+                // TODO: What's the actual host?
+                VALKEY_HOST = "localhost"
             }
 
             steps {
                 script {
+                    lock("check-concurrent-builds") {
+                        def jobname = env.JOB_NAME
+                        def output = sh(returnStdout: true, script: "python3 ./jenkins_build.py replace ${sourceRepo} ${params.PR_ID}").trim()
+                        if (output != null && output != '') {
+                            def job = Jenkins.instance.getItemByFullName(jobname)
+                            job.getBuildByNumber(output).doStop()
+                        }
+                    }
                     timeout(time: buildTimeout, unit: 'MINUTES') {
                         // TODO: Check if a build already exists and if so reuse it
                         def rc = sh(returnStatus: true, script: "./scratch-build.sh koji ${releaseId}-candidate git+https://src.fedoraproject.org/${sourceRepo}.git#${params.PR_COMMIT}")
@@ -121,6 +131,9 @@ pipeline {
 
     post {
         success {
+            lock("check-concurrent-builds") {
+                sh(script: "python3 ./jenkins_build.py finish ${sourceRepo} ${params.PR_ID}")
+            }
             sendMessage(type: 'complete', artifactId: artifactId, pipelineMetadata: pipelineMetadata, dryRun: isPullRequest(), runUrl: kojiUrl)
 
             // Run dist-git tests on the scratch build, and report results back to the pull request

--- a/jenkins_build.py
+++ b/jenkins_build.py
@@ -1,0 +1,81 @@
+# /// script
+# dependencies = [
+#   "valkey[libvalkey]",
+# ]
+# ///
+
+import argparse
+import datetime
+import os
+
+
+import valkey
+
+
+# Using a high build_id cache time higher than the actual timeout
+# This should delete any leftover caches if they leaked
+BUILD_ID_CACHE_TIME = datetime.timedelta(days=1.25)
+
+
+def replace_build(valkey_client: valkey.Valkey, args: argparse.Namespace) -> None:
+    # Set the current build-id for the running jobs and get the previous one if it existed
+    running_job_var = f"fedora-ci/dist-git-build-pipeline/{args.repo_full_name}#{args.pr_id}/running-job"
+    old_build = valkey_client.set(
+        running_job_var,
+        args.build_id,
+        get=True,
+        ex=BUILD_ID_CACHE_TIME,
+    )
+    if old_build:
+        print(old_build.decode())
+
+
+def finish_build(valkey_client: valkey.Valkey, args: argparse.Namespace) -> None:
+    # Delete the current build-id from the cache store
+    running_job_var = f"fedora-ci/dist-git-build-pipeline/{args.repo_full_name}#{args.pr_id}/running-job"
+    current_build_id = valkey_client.get(running_job_var)
+    if not current_build_id:
+        print("Unexpected: The build ID was not in the running-job")
+    elif current_build_id.decode() != args.build_id:
+        print("Unexpected: There is a different build ID currently running")
+    else:
+        # Expected case
+        valkey_client.delete(running_job_var)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=os.environ.get("VALKEY_HOST", "localhost"))
+    parser.add_argument("--port", default=6379, type=int)
+    parser.add_argument("--db", default=0, type=int)
+
+    actions = parser.add_subparsers(required=True, dest="action")
+
+    replace_parser = actions.add_parser("replace")
+    replace_parser.add_argument("repo_full_name")
+    replace_parser.add_argument("pr_id")
+    replace_parser.add_argument("--build-id", default=os.environ.get("BUILD_ID"))
+
+    finish_parser = actions.add_parser("finish")
+    finish_parser.add_argument("repo_full_name")
+    finish_parser.add_argument("pr_id")
+    finish_parser.add_argument("--build-id", default=os.environ.get("BUILD_ID"))
+
+    args = parser.parse_args()
+    assert args.build_id
+
+    # We store the current (cache) state of the jobs in a valkey server
+    valkey_client = valkey.Valkey(
+        host=args.host,
+        port=args.port,
+        db=args.db,
+    )
+
+    match args.action:
+        case "replace":
+            replace_build(valkey_client, args)
+        case "finish":
+            finish_build(valkey_client, args)
+        case _:
+            raise NotImplementedError
+

--- a/koji_task.py
+++ b/koji_task.py
@@ -1,0 +1,95 @@
+# /// script
+# dependencies = [
+#   "valkey[libvalkey]",
+# ]
+# ///
+
+import argparse
+import datetime
+import os
+from pathlib import Path
+
+
+import valkey
+
+
+# Task-id caching is independent of any timeouts, might as well set it quite high
+TASK_ID_CACHE_TIME = datetime.timedelta(days=14.0)
+
+
+def find_koji_task(valkey_client: valkey.Valkey, args: argparse.Namespace) -> None:
+    # Find the lask koji task-id matching the package and commit
+    cache_path = (
+        f"fedora-ci/dist-git-build-pipeline/{args.repo_full_name}@{args.pr_commit}"
+    )
+    cached_task_id = valkey_client.get(f"{cache_path}/task-id")
+    cached_koji_url = valkey_client.get(f"{cache_path}/koji-url")
+    task_id_file = Path("task_id")
+    koji_url_file = Path("koji_url")
+    # Make sure there were not previous files there similar to scratch-build.sh
+    task_id_file.unlink(missing_ok=True)
+    koji_url_file.unlink(missing_ok=True)
+    if cached_task_id and cached_koji_url:
+        print(f"Found cached koji task_id: {cached_task_id}")
+        print(f"Found cached koji url: {cached_koji_url}")
+        # We have the values cached, so write them to the file
+        with task_id_file.open("w") as f:
+            f.write(cached_task_id)
+        with koji_url_file.open("w") as f:
+            f.write(cached_koji_url)
+    else:
+        print("No cached koji task_id found")
+
+
+def save_koji_task(valkey_client: valkey.Valkey, args: argparse.Namespace) -> None:
+    # Save the koji task-id
+    cache_path = (
+        f"fedora-ci/dist-git-build-pipeline/{args.repo_full_name}@{args.pr_commit}"
+    )
+    task_id = Path("task_id").read_text().rstrip()
+    koji_url = Path("koji_url").read_text().rstrip()
+    valkey_client.set(
+        f"{cache_path}/task-id",
+        task_id,
+        ex=TASK_ID_CACHE_TIME,
+    )
+    valkey_client.set(
+        f"{cache_path}/koji-url",
+        koji_url,
+        ex=TASK_ID_CACHE_TIME,
+    )
+    print(f"Cached koji task_id: {task_id}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=os.environ.get("VALKEY_HOST", "localhost"))
+    parser.add_argument("--port", default=6379, type=int)
+    parser.add_argument("--db", default=0, type=int)
+
+    actions = parser.add_subparsers(required=True, dest="action")
+
+    find_parser = actions.add_parser("find")
+    find_parser.add_argument("repo_full_name")
+    find_parser.add_argument("pr_id")
+
+    save_parser = actions.add_parser("save")
+    save_parser.add_argument("repo_full_name")
+    save_parser.add_argument("pr_id")
+
+    args = parser.parse_args()
+
+    # We store the current (cache) state of the jobs in a valkey server
+    valkey_client = valkey.Valkey(
+        host=args.host,
+        port=args.port,
+        db=args.db,
+    )
+
+    match args.action:
+        case "find":
+            find_koji_task(valkey_client, args)
+        case "save":
+            save_koji_task(valkey_client, args)
+        case _:
+            raise NotImplementedError


### PR DESCRIPTION
Getting the specific scratch build that was previously used is very hard, so instead, the best approach would be to cache the task_id based on the commit and repo and then restart from there.

But I am not sure how jenkins caching works and if it can restore from multiple cache or if only the latest one survives. Another issue is that this will diverge from the zuul CI since I can't find a way to do a similar caching there. If we can find a third-party place where we can store/retrieve simple files to, maybe on the fedorapeople.org.